### PR TITLE
Add git to setup docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ ssh server.address
 ```
 Follow instructions [here](http://elixir-lang.org/install.html#unix-and-unix-like) to install elixir
 ```bash
-$ sudo apt-get install nginx
+$ sudo apt-get install nginx git
 $ mix archive.install https://github.com/hashrocket/gatling_archives/raw/master/gatling.ez
 ```
 


### PR DESCRIPTION
I noticed that `gatling.load` fails with a not so great error if git isn't installed.