### PR TITLE
Utilize map_join over seperate enum iterations

### DIFF
--- a/lib/gatling/tasks/deploy.ex
+++ b/lib/gatling/tasks/deploy.ex
@@ -210,8 +210,7 @@ defmodule Mix.Tasks.Gatling.Deploy do
   def callback(env, action, type) do
     module          = env.deploy_callback_module
     callback_action = [type, action]
-                      |> Enum.map(&to_string/1)
-                      |> Enum.join("_")
+                      |> Enum.map_join("_", &to_string/1)
                       |> String.to_atom()
 
     if function_exported?(module, callback_action, 1) do

--- a/lib/gatling/tasks/upgrade.ex
+++ b/lib/gatling/tasks/upgrade.ex
@@ -132,8 +132,7 @@ defmodule Mix.Tasks.Gatling.Upgrade do
   def callback(env, action, type) do
     module          = env.upgrade_callback_module
     callback_action = [type, action]
-                      |> Enum.map(&to_string/1)
-                      |> Enum.join("_")
+                      |> Enum.map_join("_", &to_string/1)
                       |> String.to_atom()
 
     if function_exported?(module, callback_action, 1) do


### PR DESCRIPTION
We can use Enums `map_join` to get the intended result in one pass instead of iterating over the Enum twice to do the `to_string/1` and `join`. Benchmarks show a ~20% speed increase.  

(sidenote: bored, on the bench and nitpicking 😸 )