### PR TITLE
Documentation improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,39 +242,50 @@ While implementing your callback funtions. If you are going to use
 module and use `bash/3` to get a more transparent output
 
 #### Example
-Say I want to install wget before my dependencies are installed in the `deploy`
-task.  I would create a file in my project called `./deploy.exs` with the
-following:
+
+##### Deploy Callbacks
+
+Say I want to install wget before my dependencies are installed in the `deploy` task.
+Also I want to avoid complaints about the priv/static directory not existing.
+I would create a file in my project called `./deploy.exs` with the following:
 
 ```elixir
 defmodule SampleProject.DeployCallbacks do
   import Gatling.Bash
-  
+
   def before_mix_deps_get(_env) do
     bash("sudo", ~w[apt-get install wget]
   end
 
-end
-```
-This function will be called right before `mix deps get`
+  def before_mix_digest(env) do
+    # optional: release may complain about this directory not existing
+    bash("mkdir", ~w[-p priv/static], cd: env.build_dir)
 
-Say I want the server to run npm install + brunch build and recompile assets
-
-```elixir
-defmodule SampleProject.DeployCallbacks do
-  import Gatling.Bash
-  
-  def after_mix_digest(env) do
-    bash("mkdir", ~w[-p priv/static], cd: env.build_dir) # optional: release may complain about this directory not existing
-    bash("npm", ~w[install], cd: env.build_dir)
-    bash("brunch", ~w[build --production], cd: env.build_dir)
-    bash("mix", ~w[phoenix.digest -o public/static], cd: env.build_dir)
-    env
+    # you might also want to add the asset compiling here.
+    # see the upgrade example below for details.
   end
 
 end
 ```
-This function will be called right after `mix digest`
+
+This wget install function will be called right before `mix deps get` and the
+`mkdir` will happen before `mix phoenix.digest`.
+
+##### Upgrade Callbacks
+
+Say I want the server to run `npm install` and recompile assets on upgrade:
+
+```elixir
+defmodule SampleProject.UpgradeCallbacks do
+  import Gatling.Bash
+
+  def before_mix_digest(env) do
+    bash("npm", ~w[install], cd: env.build_dir)
+    bash("npm", ~w[run deploy], cd: env.build_dir)
+  end
+
+end
+```
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Set your environment to `prod` by adding the following to `/etc/environment`
 MIX_ENV=prod
 ```
 
-For the initial deploy. Run `$ sudo mix gatling.deploy {project_name}` and Gatling
+For the initial deploy. Run `$ sudo --preserve-env mix gatling.deploy {project_name}` and Gatling
 will do the following.
 
 - Create a `distillery` release and put all the parts in the right place

--- a/README.md
+++ b/README.md
@@ -248,7 +248,8 @@ following:
 
 ```elixir
 defmodule SampleProject.DeployCallbacks do
-
+  import Gatling.Bash
+  
   def before_mix_deps_get(_env) do
     bash("sudo", ~w[apt-get install wget]
   end
@@ -261,7 +262,8 @@ Say I want the server to run npm install + brunch build and recompile assets
 
 ```elixir
 defmodule SampleProject.DeployCallbacks do
-
+  import Gatling.Bash
+  
   def after_mix_digest(env) do
     bash("mkdir", ~w[-p priv/static], cd: env.build_dir) # optional: release may complain about this directory not existing
     bash("npm", ~w[install], cd: env.build_dir)

--- a/lib/gatling/git_hook_template.sh.eex
+++ b/lib/gatling/git_hook_template.sh.eex
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 unset GIT_DIR
-exec sudo mix gatling.receive <%=@project%>
+exec sudo --preserve-env mix gatling.receive <%=@project%>

--- a/lib/gatling/tasks/deploy.ex
+++ b/lib/gatling/tasks/deploy.ex
@@ -144,7 +144,7 @@ defmodule Mix.Tasks.Gatling.Deploy do
 
   @spec configure_nginx(gatling_env) :: gatling_env
   @doc """
-  Create an nginx.cong file to configure a reverse proxy to the 
+  Create an nginx.cong file to configure a reverse proxy to the
   deploying application. Install the file in:
 
   `/etc/nginx/sites-available/<project>`
@@ -172,13 +172,13 @@ defmodule Mix.Tasks.Gatling.Deploy do
 
   @spec mix_ecto_setup(gatling_env) :: gatling_env
   @doc """
-  If the task `mix ecto.create` is available (it is assumed the deploying 
-  application has Ecto) then create the database, run migrations, 
+  If the task `mix ecto.create` is available (it is assumed the deploying
+  application has Ecto) then create the database, run migrations,
   and run the seeds file.
   """
   def mix_ecto_setup(%Gatling.Env{}=env) do
     if (Enum.find(env.available_tasks, fn(task)-> task == "ecto.create" end)) do
-      bash("mix", ~w[do ecto.create, ecto.migrate, run priv/repo/seeds.exs], [cd: env.build_dir])
+      bash("mix", ~w[ecto.setup], [cd: env.build_dir])
     end
     env
   end

--- a/lib/gatling/tasks/deploy.ex
+++ b/lib/gatling/tasks/deploy.ex
@@ -128,7 +128,7 @@ defmodule Mix.Tasks.Gatling.Deploy do
   Also makes the following comands (created by distillery) available in your deployment server:
 
   ```bash
-  $ sudo service <project> start|start_boot <file>|foreground|stop|restart|reboot|ping|rpc <m> <f> [<a>]|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript|command <m> <f> <args>
+  $ sudo --preserve-env service <project> start|start_boot <file>|foreground|stop|restart|reboot|ping|rpc <m> <f> [<a>]|console|console_clean|console_boot <file>|attach|remote_console|upgrade|escript|command <m> <f> <args>
   ```
   """
   def install_init_script(%Gatling.Env{}=env) do


### PR DESCRIPTION
The first examples include the import, the latter two don't. I also made the examples a bit clearer and moved asset compiling to the before `mix phoenix.digest` hook.