### PR TITLE
Fix wrong path for releases. Fixes #39

### DIFF
--- a/lib/gatling/utilities.ex
+++ b/lib/gatling/utilities.ex
@@ -110,10 +110,10 @@ defmodule Gatling.Utilities do
 
   @spec releases(project) :: list(binary())
   @doc """
-  List all releases found in ~/<project>/rel/<project>/releases
+  List all releases found in Distillery's releases dir
   """
   def releases(project) do
-    path = Path.join([build_dir(project), "rel", project, "releases"])
+    path = releases_path(project)
     if File.exists?(path) do
       path
       |> File.ls!()
@@ -186,6 +186,23 @@ defmodule Gatling.Utilities do
     Path.join(upgrade_dir(project), "#{project}.tar.gz")
   end
 
+  @spec releases_path(project) :: binary()
+  @doc """
+  Location of Distillery's relases directory inside the `build_dir`
+
+  `~/<project>/_build/prod/rel/<project/releases`
+  """
+  def releases_path(project) do
+    Path.join([
+      build_dir(project),
+      "_build",
+      "prod",
+      "rel",
+      project,
+      "releases"
+    ])
+  end
+
   @spec built_release_path(project) :: binary()
   @doc """
   Location of the release after it's been generated. Located inside the `build_dir`
@@ -194,12 +211,7 @@ defmodule Gatling.Utilities do
   """
   def built_release_path(project) do
     Path.join([
-      build_dir(project),
-      "_build",
-      "prod",
-      "rel",
-      project,
-      "releases",
+      releases_path(project),
       version(project),
       "#{project}.tar.gz",
     ])

--- a/test/lib/gatling/utilities_test.exs
+++ b/test/lib/gatling/utilities_test.exs
@@ -5,8 +5,7 @@ defmodule Gatling.UtilitiesTest do
 
   defp release_dir(version) do
     Path.join([
-      Utilities.build_dir("sample_project"),
-      "rel", "sample_project", "releases",
+      Utilities.releases_path("sample_project"),
       version
     ])
   end


### PR DESCRIPTION
The problem in #39 is here: https://github.com/hashrocket/gatling/blob/master/lib/gatling/utilities.ex#L116

That part is not using Distillery's new path, so it looks in a wrong folder for previous releases, finds none and then calls `mix release --upgrade --upfrom= --warnings-as-errors --env=prod` with an empty option for `upfrom`, leading to that error.

This PR fixes that.