### PR TITLE
Do not stream output from upgrade check

### DIFF
--- a/lib/gatling/tasks/receive.ex
+++ b/lib/gatling/tasks/receive.ex
@@ -15,7 +15,7 @@ defmodule Mix.Tasks.Gatling.Receive do
 
   @spec run([project]) :: gatling_env
   def run([project]) do
-    case bash("service", ~w[#{project} ping]) do
+    case bash("service", ~w[#{project} ping], into: "") do
       {"pong\n", 0} ->
         Mix.Tasks.Gatling.Upgrade.upgrade(project)
 


### PR DESCRIPTION
Since we are matching on the string output of the bash command, we cannot stream the output of the command.

Related to #43