### PR TITLE
Check for .env existence before reading it

### DIFF
--- a/lib/gatling/init_script_template.sh.eex
+++ b/lib/gatling/init_script_template.sh.eex
@@ -13,6 +13,6 @@ export MIX_ENV=prod
 export PORT=<%= @port %>
 export HOME=<%= System.user_home %>/deployments/<%= @project_name %>
 
-export $(cat <%= System.user_home %>/deployments/<%= @project_name %>/.env)
+[ -f $HOME/.env ] && export $(cat $HOME/.env)
 
 <%= System.user_home %>/deployments/<%=@project_name%>/bin/<%=@project_name%> "$1" "$2"


### PR DESCRIPTION
Check if the .env file exists before we read it in the init script template.

Related to #43